### PR TITLE
fix removeBackButtonListener on F8DrawerLayout willUnmount

### DIFF
--- a/js/common/F8DrawerLayout.js
+++ b/js/common/F8DrawerLayout.js
@@ -56,7 +56,7 @@ class F8DrawerLayout extends React.Component {
   }
 
   componentWillUnmount() {
-    this.context.removeBackButtonListener(this.closeDrawer);
+    this.context.removeBackButtonListener(this.handleBackButton);
     this._drawer = null;
   }
 


### PR DESCRIPTION
it should remove `this.handleBackButton` instead of `this.closeDrawer`