### PR TITLE
Switch to NavigationExperimental

### DIFF
--- a/js/F8App.js
+++ b/js/F8App.js
@@ -27,7 +27,6 @@
 
 var React = require('React');
 var AppState = require('AppState');
-var LoginScreen = require('./login/LoginScreen');
 var PushNotificationsController = require('./PushNotificationsController');
 var StyleSheet = require('StyleSheet');
 var F8Navigator = require('F8Navigator');
@@ -77,9 +76,6 @@ var F8App = React.createClass({
   },
 
   render: function() {
-    if (!this.props.isLoggedIn) {
-      return <LoginScreen />;
-    }
     return (
       <View style={styles.container}>
         <StatusBar
@@ -103,7 +99,6 @@ var styles = StyleSheet.create({
 
 function select(store) {
   return {
-    isLoggedIn: store.user.isLoggedIn || store.user.hasSkippedLogin,
   };
 }
 

--- a/js/F8NavigationCard.js
+++ b/js/F8NavigationCard.js
@@ -1,0 +1,134 @@
+/**
+ * Copyright 2016 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE
+ *
+ * @providesModule F8NavigationCard
+ * @flow
+ */
+'use strict';
+
+const Animated = require('Animated');
+const React = require('React');
+const ReactComponentWithPureRenderMixin = require('ReactComponentWithPureRenderMixin');
+const StyleSheet = require('StyleSheet');
+const F8NavigationCardPanResponder = require('./F8NavigationCardPanResponder');
+const F8NavigationCardStyleInterpolator = require('./F8NavigationCardStyleInterpolator');
+const View = require('View');
+
+import type  {
+  NavigationPanPanHandlers,
+  NavigationSceneRenderer,
+  NavigationSceneRendererProps,
+} from 'NavigationTypeDefinition';
+
+type Props = NavigationSceneRendererProps & {
+  style: any,
+  panHandlers: ?NavigationPanPanHandlers,
+  renderScene: NavigationSceneRenderer,
+};
+
+const {PropTypes} = React;
+
+const propTypes = {
+  // ...NavigationPropTypes.SceneRenderer,
+  style: PropTypes.any,
+  // panHandlers: NavigationPropTypes.panHandlers,
+  renderScene: PropTypes.func.isRequired,
+  isVertical: PropTypes.bool,
+};
+
+/**
+ * Component that renders the scene as card for the <NavigationCardStack />.
+ */
+class F8NavigationCard extends React.Component<any, Props, any> {
+  props: Props;
+
+  shouldComponentUpdate(nextProps: Props, nextState: any): boolean {
+    return ReactComponentWithPureRenderMixin.shouldComponentUpdate.call(
+      this,
+      nextProps,
+      nextState
+    );
+  }
+
+  render(): ReactElement {
+    const {
+      panHandlers,
+      renderScene,
+      style,
+      ...props, /* NavigationSceneRendererProps */
+    } = this.props;
+
+    let viewStyle = null;
+    if (style === undefined) {
+      // fall back to default style.
+      const interpolator = this.props.isVertical ? F8NavigationCardStyleInterpolator.forVertical : F8NavigationCardStyleInterpolator.forHorizontal;
+      viewStyle = interpolator(props);
+    } else {
+      viewStyle = style;
+    }
+
+    const  {
+      navigationState,
+      scene,
+    } = props;
+
+    const interactive = navigationState.index === scene.index && !scene.isStale;
+    const pointerEvents = interactive ? 'auto' : 'none';
+
+    let viewPanHandlers = null;
+    if (interactive) {
+      if (panHandlers === undefined) {
+        const responder = this.props.isVertical ? F8NavigationCardPanResponder.forVertical : F8NavigationCardPanResponder.forHorizontal;
+        viewPanHandlers = responder(props);
+      } else {
+        viewPanHandlers = panHandlers;
+      }
+    }
+
+    return (
+      <Animated.View
+        {...viewPanHandlers}
+        pointerEvents={pointerEvents}
+        style={[styles.main, viewStyle]}>
+        {renderScene(props)}
+      </Animated.View>
+    );
+  }
+}
+
+F8NavigationCard.propTypes = propTypes;
+
+const styles = StyleSheet.create({
+  main: {
+    backgroundColor: 'black',
+    bottom: 0,
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    shadowColor: 'black',
+    shadowOffset: {width: 0, height: 0},
+    shadowOpacity: 0.4,
+    shadowRadius: 10,
+    top: 0,
+  },
+});
+
+module.exports = F8NavigationCard;

--- a/js/F8NavigationCardPanResponder.js
+++ b/js/F8NavigationCardPanResponder.js
@@ -1,0 +1,241 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule F8NavigationCardPanResponder
+ * @flow
+ * @typechecks
+ */
+'use strict';
+
+const Animated = require('Animated');
+const NavigationAbstractPanResponder = require('NavigationAbstractPanResponder');
+
+const clamp = require('clamp');
+
+import type {
+  NavigationPanPanHandlers,
+  NavigationSceneRendererProps,
+} from 'NavigationTypeDefinition';
+
+/**
+ * The duration of the card animation in milliseconds.
+ */
+const ANIMATION_DURATION = 250;
+
+/**
+ * The threshold to invoke the `onNavigate` action.
+ * For instance, `1 / 3` means that moving greater than 1 / 3 of the width of
+ * the view will navigate.
+ */
+const POSITION_THRESHOLD = 1 / 3;
+
+/**
+ * The threshold (in pixels) to start the gesture action.
+ */
+const RESPOND_THRESHOLD = 15;
+
+/**
+ * The distance from the edge of the navigator which gesture response can start for.
+ * For horizontal scroll views, a distance of 30 from the left of the screen is the
+ * standard maximum position to start touch responsiveness.
+ */
+const RESPOND_POSITION_MAX_HORIZONTAL = 30;
+const RESPOND_POSITION_MAX_VERTICAL = null;
+
+/**
+ * The threshold (in pixels) to finish the gesture action.
+ */
+const DISTANCE_THRESHOLD = 100;
+
+/**
+ * Primitive gesture directions.
+ */
+const Directions = {
+  'HORIZONTAL': 'horizontal',
+  'VERTICAL': 'vertical',
+};
+
+export type NavigationGestureDirection =  'horizontal' | 'vertical';
+
+/**
+ * Primitive gesture actions.
+ */
+const Actions = {
+  // The gesture to navigate backward.
+  // This is done by swiping from the left to the right or from the top to the
+  // bottom.
+  BACK: {type: 'back'},
+};
+
+/**
+ * Pan responder that handles gesture for a card in the cards stack.
+ *
+ *     +------------+
+ *   +-+            |
+ * +-+ |            |
+ * | | |            |
+ * | | |  Focused   |
+ * | | |   Card     |
+ * | | |            |
+ * +-+ |            |
+ *   +-+            |
+ *     +------------+
+ */
+class F8NavigationCardPanResponder extends NavigationAbstractPanResponder {
+
+  _isResponding: boolean;
+  _isVertical: boolean;
+  _props: NavigationSceneRendererProps;
+  _startValue: number;
+
+  constructor(
+    direction: NavigationGestureDirection,
+    props: NavigationSceneRendererProps,
+  ) {
+    super();
+    this._isResponding = false;
+    this._isVertical = direction === Directions.VERTICAL;
+    this._props = props;
+    this._startValue = 0;
+  }
+
+  onMoveShouldSetPanResponder(event: any, gesture: any): boolean {
+    const props = this._props;
+
+    if (props.navigationState.index !== props.scene.index) {
+      return false;
+    }
+
+    const layout = props.layout;
+    const isVertical = this._isVertical;
+    const index = props.navigationState.index;
+    const currentDragDistance = gesture[isVertical ? 'dy' : 'dx'];
+    const currentDragPosition = gesture[isVertical ? 'moveY' : 'moveX'];
+    const maxDragDistance = isVertical ?
+      layout.height.__getValue() :
+      layout.width.__getValue();
+
+    const positionMax = isVertical ?
+      RESPOND_POSITION_MAX_VERTICAL :
+      RESPOND_POSITION_MAX_HORIZONTAL;
+
+    if (positionMax != null && currentDragPosition > positionMax) {
+      return false;
+    }
+
+    return (
+      Math.abs(currentDragDistance) > RESPOND_THRESHOLD &&
+      maxDragDistance > 0 &&
+      index > 0
+    );
+  }
+
+  onPanResponderGrant(): void {
+    this._isResponding = false;
+    this._props.position.stopAnimation((value: number) => {
+      this._isResponding = true;
+      this._startValue = value;
+    });
+  }
+
+  onPanResponderMove(event: any, gesture: any): void {
+    if (!this._isResponding) {
+      return;
+    }
+
+    const props = this._props;
+    const layout = props.layout;
+    const isVertical = this._isVertical;
+    const axis = isVertical ? 'dy' : 'dx';
+    const index = props.navigationState.index;
+    const distance = isVertical ?
+      layout.height.__getValue() :
+      layout.width.__getValue();
+
+    const value = clamp(
+      index - 1,
+      this._startValue - (gesture[axis] / distance),
+      index
+    );
+
+    props.position.setValue(value);
+  }
+
+  onPanResponderRelease(event: any, gesture: any): void {
+    if (!this._isResponding) {
+      return;
+    }
+
+    this._isResponding = false;
+
+    const props = this._props;
+    const isVertical = this._isVertical;
+    const axis = isVertical ? 'dy' : 'dx';
+    const index = props.navigationState.index;
+    const distance = gesture[axis];
+
+    props.position.stopAnimation((value: number) => {
+      this._reset();
+       if (distance > DISTANCE_THRESHOLD  || value <= index - POSITION_THRESHOLD) {
+        props.onNavigate(Actions.BACK);
+      }
+    });
+  }
+
+  onPanResponderTerminate(): void {
+    this._isResponding = false;
+    this._reset();
+  }
+
+  _reset(): void {
+    const props = this._props;
+    Animated.timing(
+      props.position,
+      {
+        toValue: props.navigationState.index,
+        duration: ANIMATION_DURATION,
+      }
+    ).start();
+  }
+}
+
+function createPanHandlers(
+  direction: NavigationGestureDirection,
+  props: NavigationSceneRendererProps,
+): NavigationPanPanHandlers {
+  const responder = new F8NavigationCardPanResponder(direction, props);
+  return responder.panHandlers;
+}
+
+function forHorizontal(
+  props: NavigationSceneRendererProps,
+): NavigationPanPanHandlers {
+  return createPanHandlers(Directions.HORIZONTAL, props);
+}
+
+function forVertical(
+  props: NavigationSceneRendererProps,
+): NavigationPanPanHandlers {
+  return createPanHandlers(Directions.VERTICAL, props);
+}
+
+module.exports = {
+  // constants
+  ANIMATION_DURATION,
+  DISTANCE_THRESHOLD,
+  POSITION_THRESHOLD,
+  RESPOND_THRESHOLD,
+
+  // enums
+  Actions,
+  Directions,
+
+  // methods.
+  forHorizontal,
+  forVertical,
+};

--- a/js/F8NavigationCardStyleInterpolator.js
+++ b/js/F8NavigationCardStyleInterpolator.js
@@ -1,0 +1,124 @@
+/**
+ * Copyright 2016 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE
+ *
+ * @providesModule F8NavigationCardStyleInterpolator
+ * @flow
+ */
+
+'use strict';
+
+import type  {
+  NavigationSceneRendererProps,
+} from 'NavigationTypeDefinition';
+
+/**
+ * Utility that builds the style for the card in the cards stack.
+ *
+ *     +------------+
+ *   +-+            |
+ * +-+ |            |
+ * | | |            |
+ * | | |  Focused   |
+ * | | |   Card     |
+ * | | |            |
+ * +-+ |            |
+ *   +-+            |
+ *     +------------+
+ */
+
+function forHorizontal(props: NavigationSceneRendererProps): Object {
+  const {
+    layout,
+    position,
+    scene,
+  } = props;
+
+  const index = scene.index;
+  const inputRange = [index - 1, index, index + 1];
+  const width = layout.initWidth;
+
+  const opacity = position.interpolate({
+    inputRange,
+    outputRange: [1, 1, 0.3],
+  });
+
+  const scale = position.interpolate({
+    inputRange,
+    outputRange: [1, 1, 0.95],
+  });
+
+  const translateY = 0;
+  const translateX = position.interpolate({
+    inputRange,
+    outputRange: [width, 0, -10],
+  });
+
+  return {
+    opacity,
+    transform: [
+      { scale },
+      { translateX },
+      { translateY },
+    ],
+  };
+}
+
+function forVertical(props: NavigationSceneRendererProps): Object {
+  const {
+    layout,
+    position,
+    scene,
+  } = props;
+
+  const index = scene.index;
+  const inputRange = [index - 1, index, index + 1];
+  const height = layout.initHeight;
+
+  const opacity = position.interpolate({
+    inputRange,
+    outputRange: [1, 1, 0.3],
+  });
+
+  const scale = position.interpolate({
+    inputRange,
+    outputRange: [1, 1, 0.95],
+  });
+
+  const translateX = 0;
+  const translateY = position.interpolate({
+    inputRange,
+    outputRange: [height, 0, -10],
+  });
+
+  return {
+    opacity,
+    transform: [
+      { scale },
+      { translateX },
+      { translateY },
+    ],
+  };
+}
+
+module.exports = {
+  forHorizontal,
+  forVertical,
+};

--- a/js/actions/login.js
+++ b/js/actions/login.js
@@ -99,12 +99,6 @@ function logInWithFacebook(source: ?string): ThunkAction {
   };
 }
 
-function skipLogin(): Action {
-  return {
-    type: 'SKIPPED_LOGIN',
-  };
-}
-
 function logOut(): ThunkAction {
   return (dispatch) => {
     Parse.User.logOut();
@@ -149,4 +143,4 @@ function logOutWithPrompt(): ThunkAction {
   };
 }
 
-module.exports = {logInWithFacebook, skipLogin, logOut, logOutWithPrompt};
+module.exports = {logInWithFacebook, logOut, logOutWithPrompt};

--- a/js/actions/navigation.js
+++ b/js/actions/navigation.js
@@ -25,10 +25,46 @@
 'use strict';
 
 import type { Action } from './types';
+import type { Session } from '../reducers/sessions';
 
 type Tab = 'schedule' | 'my-schedule' | 'map' | 'notifications' | 'info';
 
 module.exports = {
+  back: (): Action => ({
+    type: 'BACK',
+  }),
+
+  openFilter: (): Action => ({
+    type: 'OPEN_FILTER',
+  }),
+
+  openNavDrawer: (): Action => ({
+    type: 'OPEN_NAV_DRAWER',
+  }),
+
+  openFriend: (friend: string): Action => ({
+    type: 'OPEN_FRIEND',
+    friend,
+  }),
+
+  openSharingSettings: (): Action => ({
+    type: 'OPEN_SHARING_SETTINGS',
+  }),
+
+  openLoginModal: (): Action => ({
+    type: 'OPEN_LOGIN_MODAL',
+  }),
+
+  openShare: (): Action => ({
+    type: 'OPEN_SHARE',
+  }),
+
+  openSession: (session: string, day: 1 | 2): Action => ({
+    type: 'OPEN_SESSION',
+    day,
+    session,
+  }),
+
   switchTab: (tab: Tab): Action => ({
     type: 'SWITCH_TAB',
     tab,

--- a/js/actions/types.js
+++ b/js/actions/types.js
@@ -37,13 +37,20 @@ export type Action =
   | { type: 'SUBMITTED_SURVEY_ANSWERS', id: string; }
   | { type: 'LOGGED_IN', source: ?string; data: { id: string; name: string; sharedSchedule: ?boolean; } }
   | { type: 'RESTORED_SCHEDULE', list: Array<ParseObject> }
-  | { type: 'SKIPPED_LOGIN' }
   | { type: 'LOGGED_OUT' }
+  | { type: 'BACK' }
   | { type: 'SESSION_ADDED', id: string }
   | { type: 'SESSION_REMOVED', id: string }
   | { type: 'SET_SHARING', enabled: boolean }
   | { type: 'APPLY_TOPICS_FILTER', topics: {[key: string]: boolean} }
+  | { type: 'OPEN_FRIEND', friend: string }
+  | { type: 'OPEN_NAV_DRAWER' }
+  | { type: 'OPEN_FILTER' }
   | { type: 'CLEAR_FILTER' }
+  | { type: 'OPEN_SESSION', session: string, day: 1 | 2 }
+  | { type: 'OPEN_SHARING_SETTINGS' }
+  | { type: 'OPEN_LOGIN_MODAL' }
+  | { type: 'OPEN_SHARE' }
   | { type: 'SWITCH_DAY', day: 1 | 2 }
   | { type: 'SWITCH_TAB', tab: 'schedule' | 'my-schedule' | 'map' | 'notifications' | 'info' }
   | { type: 'TURNED_ON_PUSH_NOTIFICATIONS' }

--- a/js/common/F8DrawerLayout.js
+++ b/js/common/F8DrawerLayout.js
@@ -34,11 +34,8 @@ class F8DrawerLayout extends React.Component {
   constructor(props: any, context: any) {
     super(props, context);
 
-    this.openDrawer = this.openDrawer.bind(this);
-    this.closeDrawer = this.closeDrawer.bind(this);
     this.onDrawerOpen = this.onDrawerOpen.bind(this);
     this.onDrawerClose = this.onDrawerClose.bind(this);
-    this.handleBackButton = this.handleBackButton.bind(this);
   }
 
   render() {
@@ -55,38 +52,25 @@ class F8DrawerLayout extends React.Component {
     );
   }
 
+  componentDidUpdate(lastProps: any) {
+    if (this.props.isOpen && !lastProps.isOpen) {
+      this._drawer && this._drawer.openDrawer();
+    } else if (!this.props.open && lastProps.isOpen) {
+      this._drawer && this._drawer.closeDrawer();
+    }
+  }
+
   componentWillUnmount() {
-    this.context.removeBackButtonListener(this.handleBackButton);
     this._drawer = null;
   }
 
-  handleBackButton(): boolean {
-    this.closeDrawer();
-    return true;
-  }
-
   onDrawerOpen() {
-    this.context.addBackButtonListener(this.handleBackButton);
-    this.props.onDrawerOpen && this.props.onDrawerOpen();
+    // TODO: Fire props.onDrawerOpen and onDrawerClose at the right times
   }
 
   onDrawerClose() {
-    this.context.removeBackButtonListener(this.handleBackButton);
-    this.props.onDrawerClose && this.props.onDrawerClose();
-  }
-
-  closeDrawer() {
-    this._drawer && this._drawer.closeDrawer();
-  }
-
-  openDrawer() {
-    this._drawer && this._drawer.openDrawer();
+    // TODO: Fire props.onDrawerOpen and onDrawerClose at the right times
   }
 }
-
-F8DrawerLayout.contextTypes = {
-  addBackButtonListener: React.PropTypes.func,
-  removeBackButtonListener: React.PropTypes.func,
-};
 
 module.exports = F8DrawerLayout;

--- a/js/common/ListContainer.js
+++ b/js/common/ListContainer.js
@@ -38,6 +38,9 @@ var { Text } = require('F8Text');
 var ViewPager = require('./ViewPager');
 var Platform = require('Platform');
 
+var { openNavDrawer } = require('../actions');
+var { connect } = require('react-redux');
+
 import type {Item as HeaderItem} from 'F8Header';
 
 type Props = {
@@ -52,6 +55,7 @@ type Props = {
   parallaxContent: ?ReactElement;
   stickyHeader?: ?ReactElement;
   onSegmentChange?: (segment: number) => void;
+  openNavDrawer: Function;
   children: any;
 };
 
@@ -349,7 +353,7 @@ class ListContainer extends React.Component {
   }
 
   handleShowMenu() {
-    this.context.openDrawer();
+    this.props.openNavDrawer();
   }
 }
 
@@ -358,7 +362,6 @@ ListContainer.defaultProps = {
 };
 
 ListContainer.contextTypes = {
-  openDrawer: React.PropTypes.func,
   hasUnreadNotifications: React.PropTypes.number,
 };
 
@@ -404,4 +407,10 @@ var styles = StyleSheet.create({
   },
 });
 
-module.exports = ListContainer;
+function actions(dispatch) {
+  return {
+    openNavDrawer: () => dispatch(openNavDrawer()),
+  };
+}
+
+module.exports = connect(null, actions)(ListContainer);

--- a/js/filter/FilterScreen.js
+++ b/js/filter/FilterScreen.js
@@ -40,6 +40,7 @@ const {
 const shallowEqual = require('fbjs/lib/shallowEqual');
 const {
   applyTopicsFilter,
+  back,
 } = require('../actions');
 const {connect} = require('react-redux');
 
@@ -49,8 +50,7 @@ class FilterScreen extends React.Component {
     topics: Array<string>;
     selectedTopics: {[id: string]: boolean};
     dispatch: (action: any) => void;
-    navigator: any;
-    onClose: ?() => void;
+    back: Function;
   };
   state: {
     selectedTopics: {[id: string]: boolean};
@@ -66,7 +66,6 @@ class FilterScreen extends React.Component {
 
     (this: any).applyFilter = this.applyFilter.bind(this);
     (this: any).clearFilter = this.clearFilter.bind(this);
-    (this: any).close = this.close.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -106,7 +105,7 @@ class FilterScreen extends React.Component {
 
     let leftItem, rightItem;
     if (this.props.navigator) {
-      leftItem = {title: 'Cancel', onPress: this.close};
+      leftItem = {title: 'Cancel', onPress: this.props.back};
     }
     if (selectedAnyTopics) {
       rightItem = {
@@ -152,17 +151,6 @@ class FilterScreen extends React.Component {
 
   applyFilter() {
     this.props.dispatch(applyTopicsFilter(this.state.selectedTopics));
-    this.close();
-  }
-
-  close() {
-    const {navigator, onClose} = this.props;
-    if (navigator) {
-      requestAnimationFrame(() => navigator.pop());
-    }
-    if (onClose) {
-      onClose();
-    }
   }
 
   clearFilter() {
@@ -200,4 +188,10 @@ function select(store) {
   };
 }
 
-module.exports = connect(select)(FilterScreen);
+function actions(dispatch) {
+  return {
+    back: () => dispatch(back()),
+  };
+}
+
+module.exports = connect(select, actions)(FilterScreen);

--- a/js/login/LoginModal.js
+++ b/js/login/LoginModal.js
@@ -31,11 +31,12 @@ var StyleSheet = require('StyleSheet');
 var { Text } = require('F8Text');
 var View = require('View');
 var F8Button = require('F8Button');
-var Navigator = require('Navigator');
+
+var { connect } = require('react-redux');
+var { back } = require('../actions');
 
 class LoginModal extends React.Component {
   props: {
-    navigator: Navigator;
     onLogin: () => void;
   };
 
@@ -56,7 +57,7 @@ class LoginModal extends React.Component {
             type="secondary"
             caption="Not Now"
             source="Modal"
-            onPress={() => this.props.navigator.pop()}
+            onPress={() => this.props.back()}
           />
         </Image>
       </View>
@@ -64,10 +65,16 @@ class LoginModal extends React.Component {
   }
 
   loggedIn() {
-    this.props.navigator.pop();
+    this.props.back();
     this.props.onLogin();
   }
 }
+
+const actions = (dispatch, props) => ({
+  back: () => dispatch(back()),
+});
+
+LoginModal = connect(null, actions)(LoginModal);
 
 var styles = StyleSheet.create({
   container: {

--- a/js/login/LoginScreen.js
+++ b/js/login/LoginScreen.js
@@ -35,7 +35,7 @@ var { Text } = require('F8Text');
 var LoginButton = require('../common/LoginButton');
 var TouchableOpacity = require('TouchableOpacity');
 
-var { skipLogin } = require('../actions');
+var { back } = require('../actions');
 var { connect } = require('react-redux');
 
 class LoginScreen extends React.Component {
@@ -60,7 +60,7 @@ class LoginScreen extends React.Component {
           accessibilityLabel="Skip login"
           accessibilityTraits="button"
           style={styles.skip}
-          onPress={() => this.props.dispatch(skipLogin())}>
+          onPress={() => this.props.dispatch(back())}>
           <Animated.Image
             style={this.fadeIn(2800)}
             source={require('./img/x.png')}

--- a/js/reducers/navigation.js
+++ b/js/reducers/navigation.js
@@ -25,6 +25,8 @@
 'use strict';
 
 import type {Action} from '../actions/types';
+var BackAndroid = require('BackAndroid');
+var Platform = require('Platform');
 
 export type Tab =
     'schedule'
@@ -36,16 +38,186 @@ export type Tab =
 
 export type Day = 1 | 2;
 
+type ModalState = {
+  type: string,
+};
+
 type State = {
   tab: Tab;
   day: Day;
+  isFilterDrawerOpen: boolean;
+  isNavDrawerOpen: boolean;
+  openModals: Array<ModalState>;
 };
 
-const initialState: State = { tab: 'schedule', day: 1 };
+const initialState: State = {
+  tab: 'schedule',
+  day: 1,
+  isFilterDrawerOpen: false,
+  isNavDrawerOpen: false,
+  openModals: [
+    {
+      key: 'InitialRoute',
+      type: 'MainTabs',
+    },
+    {
+      key: 'InitialLoginRoute',
+      type: 'InitialLogin',
+    },
+  ],
+};
 
 function navigation(state: State = initialState, action: Action): State {
+
+  if (action.type === 'LOGGED_IN') {
+    const nonLoginModals = state.openModals.filter(modal =>
+      modal.type !== 'InitialLogin' && modal.type !== 'LoginModal'
+    );
+    if (state.openModals.length !== nonLoginModals.length) {
+      return {
+        ...state,
+        isNavDrawerOpen: false,
+        openModals: nonLoginModals,
+      };
+    }
+    if (state.isNavDrawerOpen) {
+      return {
+        ...state,
+        isNavDrawerOpen: false,
+      };
+    }
+  }
+
   if (action.type === 'SWITCH_TAB') {
-    return {...state, tab: action.tab};
+    return {
+      ...state,
+      isNavDrawerOpen: false,
+      tab: action.tab,
+    };
+  }
+  if (action.type === 'BACK') {
+    if (state.isFilterDrawerOpen || state.isNavDrawerOpen) {
+      return {
+        ...state,
+        isFilterDrawerOpen: false,
+        isNavDrawerOpen: false,
+      };
+    }
+    if (state.openModals.length > 1) {
+      return {
+        ...state,
+        openModals: state.openModals.slice(0, state.openModals.length - 1),
+      };
+    }
+    if (state.tab !== 'schedule') {
+      return {
+        ...state,
+        tab: 'schedule',
+      };
+    }
+    // Ideally our action caller could handle the back behavior, but it has no way of
+    // immediately seeing if the dispatched back action has successfully changed state. 
+    BackAndroid.exitApp();
+    return state;
+  }
+  if (action.type === 'OPEN_NAV_DRAWER') {
+    return {
+      ...state,
+      isNavDrawerOpen: true,
+    };
+  }
+  if (action.type === 'OPEN_SESSION') {
+    return {
+      ...state,
+      openModals: [
+        ...state.openModals,
+        {
+          key: `Modal-${Date.now()}`,
+          type: 'Session',
+          session: action.session,
+          day: action.day,
+        },
+      ],
+    };
+  }
+  if (action.type === 'OPEN_FRIEND') {
+    return {
+      ...state,
+      openModals: [
+        ...state.openModals,
+        {
+          key: `Modal-${Date.now()}`,
+          type: 'Friend',
+          friend: action.friend,
+        },
+      ],
+    };
+  }
+  if (action.type === 'OPEN_FILTER') {
+    if (Platform.OS === 'android') {
+      return {
+        ...state,
+        isFilterDrawerOpen: true,
+      };
+    }
+    return {
+      ...state,
+      openModals: [
+        ...state.openModals,
+        {
+          key: `Modal-${Date.now()}`,
+          type: 'Filter',
+        },
+      ],
+    };
+  }
+  if (action.type === 'OPEN_SHARING_SETTINGS') {
+    return {
+      ...state,
+      isNavDrawerOpen: false,
+      openModals: [
+        ...state.openModals,
+        {
+          key: `Modal-${Date.now()}`,
+          type: 'ShareSettings',
+        },
+      ],
+    };
+  }
+  if (action.type === 'LOGGED_OUT') {
+    const nonAuthModals = state.openModals.filter(modal =>
+      modal.type !== 'ShareSettings'
+    );
+    if (state.openModals.length !== nonAuthModals.length) {
+      return {
+        ...state,
+        openModals: nonAuthModals,
+      };
+    }
+  }
+  if (action.type === 'OPEN_LOGIN_MODAL') {
+    return {
+      ...state,
+      openModals: [
+        ...state.openModals,
+        {
+          key: `Modal-${Date.now()}`,
+          type: 'LoginModal',
+        },
+      ],
+    };
+  }
+  if (action.type === 'OPEN_SHARE') {
+    return {
+      ...state,
+      openModals: [
+        ...state.openModals,
+        {
+          key: `Modal-${Date.now()}`,
+          type: 'Share',
+        },
+      ],
+    };
   }
   if (action.type === 'SWITCH_DAY') {
     return {...state, day: action.day};

--- a/js/reducers/user.js
+++ b/js/reducers/user.js
@@ -28,7 +28,6 @@ import type {Action} from '../actions/types';
 
 export type State = {
   isLoggedIn: boolean;
-  hasSkippedLogin: boolean;
   sharedSchedule: ?boolean;
   id: ?string;
   name: ?string;
@@ -36,7 +35,6 @@ export type State = {
 
 const initialState = {
   isLoggedIn: false,
-  hasSkippedLogin: false,
   sharedSchedule: null,
   id: null,
   name: null,
@@ -50,19 +48,9 @@ function user(state: State = initialState, action: Action): State {
     }
     return {
       isLoggedIn: true,
-      hasSkippedLogin: false,
       sharedSchedule,
       id,
       name,
-    };
-  }
-  if (action.type === 'SKIPPED_LOGIN') {
-    return {
-      isLoggedIn: false,
-      hasSkippedLogin: true,
-      sharedSchedule: null,
-      id: null,
-      name: null,
     };
   }
   if (action.type === 'LOGGED_OUT') {

--- a/js/tabs/F8TabsView.ios.js
+++ b/js/tabs/F8TabsView.ios.js
@@ -35,7 +35,6 @@ var MyScheduleView = require('./schedule/MyScheduleView');
 var React = require('React');
 var TabBarIOS = require('TabBarIOS');
 var TabBarItemIOS = require('TabBarItemIOS');
-var Navigator = require('Navigator');
 var unseenNotificationsCount = require('./notifications/unseenNotificationsCount');
 
 var { switchTab } = require('../actions');
@@ -48,7 +47,6 @@ class F8TabsView extends React.Component {
     tab: Tab;
     day: Day;
     onTabSelect: (tab: Tab) => void;
-    navigator: Navigator;
   };
 
   constructor(props) {
@@ -82,7 +80,6 @@ class F8TabsView extends React.Component {
           icon={scheduleIcon}
           selectedIcon={scheduleIconSelected}>
           <GeneralScheduleView
-            navigator={this.props.navigator}
             onDayChange={this.handleDayChange}
           />
         </TabBarItemIOS>
@@ -93,7 +90,6 @@ class F8TabsView extends React.Component {
           icon={require('./schedule/img/my-schedule-icon.png')}
           selectedIcon={require('./schedule/img/my-schedule-icon-active.png')}>
           <MyScheduleView
-            navigator={this.props.navigator}
             onJumpToSchedule={() => this.props.onTabSelect('schedule')}
           />
         </TabBarItemIOS>
@@ -112,7 +108,7 @@ class F8TabsView extends React.Component {
           badge={this.props.notificationsBadge || null}
           icon={require('./notifications/img/notifications-icon.png')}
           selectedIcon={require('./notifications/img/notifications-icon-active.png')}>
-          <F8NotificationsView navigator={this.props.navigator} />
+          <F8NotificationsView />
         </TabBarItemIOS>
         <TabBarItemIOS
           title="Info"
@@ -120,7 +116,7 @@ class F8TabsView extends React.Component {
           onPress={this.onTabSelect.bind(this, 'info')}
           icon={require('./info/img/info-icon.png')}
           selectedIcon={require('./info/img/info-icon-active.png')}>
-          <F8InfoView navigator={this.props.navigator} />
+          <F8InfoView />
         </TabBarItemIOS>
       </TabBarIOS>
     );

--- a/js/tabs/notifications/F8NotificationsView.js
+++ b/js/tabs/notifications/F8NotificationsView.js
@@ -39,6 +39,7 @@ var View = require('View');
 var findSessionByURI = require('findSessionByURI');
 var { connect } = require('react-redux');
 var {
+  openSession,
   turnOnPushNotifications,
   skipPushNotifications,
   TEST_MENU,
@@ -131,7 +132,7 @@ class F8NotificationsView extends React.Component {
     if (notification.url) {
       var session = findSessionByURI(this.props.sessions, notification.url);
       if (session) {
-        this.props.navigator.push({session});
+        this.props.openSession(session.id, session.day);
       } else {
         Linking.openURL(notification.url);
       }
@@ -198,6 +199,7 @@ function select(state) {
 
 function actions(dispatch) {
   return {
+    openSession: (session, day) => dispatch(openSession(session, day)),
     onTurnOnNotifications: () => dispatch(turnOnPushNotifications()),
     onSkipNotifications: () => dispatch(skipPushNotifications()),
     dispatch,

--- a/js/tabs/schedule/F8SessionDetails.js
+++ b/js/tabs/schedule/F8SessionDetails.js
@@ -43,8 +43,8 @@ var View = require('View');
 var AddToScheduleButton = require('./AddToScheduleButton');
 
 var formatDuration = require('./formatDuration');
-var {connect} = require('react-redux');
-var {addToSchedule, removeFromScheduleWithPrompt} = require('../../actions');
+var { connect } = require('react-redux');
+var { addToSchedule, openFriend, openLoginModal, openShare, removeFromScheduleWithPrompt } = require('../../actions');
 
 var F8SessionDetails = React.createClass({
   mixins: [Subscribable.Mixin],
@@ -80,7 +80,7 @@ var F8SessionDetails = React.createClass({
         <F8FriendGoing
           key={friend.id}
           friend={friend}
-          onPress={() => this.props.navigator.push({friend})}
+          onPress={() => this.props.openFriend(friend.id)}
         />
       )
     );
@@ -174,14 +174,11 @@ var F8SessionDetails = React.createClass({
 
   addToSchedule: function() {
     if (!this.props.isLoggedIn) {
-      this.props.navigator.push({
-        login: true, // TODO: Proper route
-        callback: this.addToSchedule,
-      });
+      this.props.openLoginModal(this.addToSchedule);
     } else {
       this.props.addToSchedule();
       if (this.props.sharedSchedule === null) {
-        setTimeout(() => this.props.navigator.push({share: true}), 1000);
+        setTimeout(() => this.props.openShare(), 1000);
       }
     }
   },
@@ -330,6 +327,9 @@ function actions(dispatch, props) {
   let id = props.session.id;
   return {
     addToSchedule: () => dispatch(addToSchedule(id)),
+    openLoginModal: (cb) => dispatch(openLoginModal(cb)),
+    openShare: () => dispatch(openShare()),
+    openFriend: (friend) => dispatch(openFriend(friend)),
     removeFromScheduleWithPrompt:
       () => dispatch(removeFromScheduleWithPrompt(props.session)),
   };

--- a/js/tabs/schedule/FriendsListView.js
+++ b/js/tabs/schedule/FriendsListView.js
@@ -24,18 +24,20 @@
 'use strict';
 
 var EmptySchedule = require('./EmptySchedule');
-var Navigator = require('Navigator');
 var React = require('React');
 var SessionsSectionHeader = require('./SessionsSectionHeader');
 var InviteFriendsButton = require('./InviteFriendsButton');
 var PureListView = require('../../common/PureListView');
 var FriendCell = require('./FriendCell');
 
+var { connect } = require('react-redux');
+var { openFriend } = require('../../actions');
+ 
 type Friend = any;
 
 type Props = {
+  openFriend: Function,
   friends: Array<Friend>;
-  navigator: Navigator;
 };
 
 class FriendsListView extends React.Component {
@@ -96,7 +98,7 @@ class FriendsListView extends React.Component {
   }
 
   openFriendsSchedule(friend: Friend) {
-    this.props.navigator.push({friend});
+    this.props.openFriend(friend.id);
   }
 
   storeInnerRef(ref: ?PureListView) {
@@ -112,4 +114,14 @@ class FriendsListView extends React.Component {
   }
 }
 
-module.exports = FriendsListView;
+function select(store) {
+  return {};
+}
+
+function actions(dispatch) {
+  return {
+    openFriend: (friend) => dispatch(openFriend(friend)),
+  };
+}
+
+module.exports = connect(select, actions)(FriendsListView);

--- a/js/tabs/schedule/FriendsScheduleView.js
+++ b/js/tabs/schedule/FriendsScheduleView.js
@@ -23,7 +23,6 @@
  */
 'use strict';
 
-var Navigator = require('Navigator');
 var ProfilePicture = require('../../common/ProfilePicture');
 var React = require('React');
 var EmptySchedule = require('./EmptySchedule');
@@ -32,6 +31,7 @@ var ListContainer = require('ListContainer');
 var ScheduleListView = require('./ScheduleListView');
 
 var { connect } = require('react-redux');
+import {back} from '../../actions/';
 
 import type {Session} from '../../reducers/sessions';
 import type {FriendsSchedule} from '../../reducers/friendsSchedules';
@@ -39,9 +39,9 @@ import type {FriendsSchedule} from '../../reducers/friendsSchedules';
 var { createSelector } = require('reselect');
 
 type Props = {
+  back: Function;
   sessions: Array<Session>;
   friend: FriendsSchedule;
-  navigator: Navigator;
 };
 
 class FriendsScheduleView extends React.Component {
@@ -55,7 +55,7 @@ class FriendsScheduleView extends React.Component {
   render() {
     const backItem = {
       icon: require('../../common/img/back_white.png'),
-      onPress: () => this.props.navigator.pop(),
+      onPress: () => this.props.back(),
     };
     const firstName = this.props.friend.name.split(' ')[0];
     return (
@@ -71,14 +71,12 @@ class FriendsScheduleView extends React.Component {
           day={1}
           sessions={this.props.sessions}
           renderEmptyList={this.renderEmptyList}
-          navigator={this.props.navigator}
         />
         <ScheduleListView
           title="Day 2"
           day={2}
           sessions={this.props.sessions}
           renderEmptyList={this.renderEmptyList}
-          navigator={this.props.navigator}
         />
       </ListContainer>
     );
@@ -94,16 +92,30 @@ class FriendsScheduleView extends React.Component {
   }
 }
 
-const data = createSelector(
+const getFriend = (store, props) => store.friendsSchedules.find(s => s.id === props.friend);
+
+const getFriendSchedule = createSelector(
+  getFriend,
+  (friend) => friend.schedule,
+);
+
+const getSessions = createSelector(
   (store) => store.sessions,
-  (store, props) => props.friend.schedule,
+  getFriendSchedule,
   (sessions, schedule) => FilterSessions.bySchedule(sessions, schedule),
 );
 
 function select(store, props) {
   return {
-    sessions: data(store, props),
+    friend: getFriend(store, props),
+    sessions: getSessions(store, props),
   };
 }
 
-module.exports = connect(select)(FriendsScheduleView);
+function actions(dispatch) {
+  return {
+    back: () => dispatch(back()),
+  };
+}
+
+module.exports = connect(select, actions)(FriendsScheduleView);

--- a/js/tabs/schedule/GeneralScheduleView.js
+++ b/js/tabs/schedule/GeneralScheduleView.js
@@ -27,7 +27,6 @@ var EmptySchedule = require('./EmptySchedule');
 var FilterHeader = require('./FilterHeader');
 var FilterSessions = require('./filterSessions');
 var ListContainer = require('ListContainer');
-var Navigator = require('Navigator');
 var React = require('React');
 var Platform = require('Platform');
 var F8DrawerLayout = require('F8DrawerLayout');
@@ -35,7 +34,7 @@ var ScheduleListView = require('./ScheduleListView');
 var FilterScreen = require('../../filter/FilterScreen');
 
 var { connect } = require('react-redux');
-var {switchDay} = require('../../actions');
+var { back, openFilter, switchDay } = require('../../actions');
 
 import type {Session} from '../../reducers/sessions';
 
@@ -51,15 +50,16 @@ const data = createSelector(
 type Props = {
   filter: any;
   day: number;
+  isFilterDrawerOpen: boolean;
   sessions: Array<Session>;
-  navigator: Navigator;
   logOut: () => void;
+  back: () => void;
+  openFilter: () => void;
   switchDay: (day: number) => void;
 };
 
 class GeneralScheduleView extends React.Component {
   props: Props;
-  _drawer: ?F8DrawerLayout;
 
   constructor(props) {
     super(props);
@@ -96,14 +96,12 @@ class GeneralScheduleView extends React.Component {
           day={1}
           sessions={this.props.sessions}
           renderEmptyList={this.renderEmptyList}
-          navigator={this.props.navigator}
         />
         <ScheduleListView
           title="Day 2"
           day={2}
           sessions={this.props.sessions}
           renderEmptyList={this.renderEmptyList}
-          navigator={this.props.navigator}
         />
       </ListContainer>
     );
@@ -113,9 +111,11 @@ class GeneralScheduleView extends React.Component {
     }
     return (
       <F8DrawerLayout
-        ref={(drawer) => this._drawer = drawer}
         drawerWidth={300}
         drawerPosition="right"
+        isOpen={this.props.isFilterDrawerOpen}
+        onDrawerOpen={this.props.openFilter}
+        onDrawerClose={this.props.back}
         renderNavigationView={this.renderNavigationView}>
         {content}
       </F8DrawerLayout>
@@ -123,7 +123,7 @@ class GeneralScheduleView extends React.Component {
   }
 
   renderNavigationView() {
-    return <FilterScreen onClose={() => this._drawer && this._drawer.closeDrawer()} />;
+    return <FilterScreen onClose={this.props.back} />;
   }
 
   renderEmptyList(day: number) {
@@ -136,11 +136,7 @@ class GeneralScheduleView extends React.Component {
   }
 
   openFilterScreen() {
-    if (Platform.OS === 'ios') {
-      this.props.navigator.push({ filter: 123 });
-    } else {
-      this._drawer && this._drawer.openDrawer();
-    }
+    this.props.openFilter();
   }
 
   switchDay(page) {
@@ -150,6 +146,7 @@ class GeneralScheduleView extends React.Component {
 
 function select(store) {
   return {
+    isFilterDrawerOpen: store.navigation.isFilterDrawerOpen,
     day: store.navigation.day,
     filter: store.filter,
     sessions: data(store),
@@ -158,6 +155,8 @@ function select(store) {
 
 function actions(dispatch) {
   return {
+    back: () => dispatch(back()),
+    openFilter: () => dispatch(openFilter()),
     switchDay: (day) => dispatch(switchDay(day)),
   };
 }

--- a/js/tabs/schedule/MyScheduleView.js
+++ b/js/tabs/schedule/MyScheduleView.js
@@ -28,7 +28,6 @@ var F8Button = require('F8Button');
 var FilterSessions = require('./filterSessions');
 var ListContainer = require('ListContainer');
 var LoginButton = require('../../common/LoginButton');
-var Navigator = require('Navigator');
 var ProfilePicture = require('../../common/ProfilePicture');
 var React = require('React');
 var PureListView = require('../../common/PureListView');
@@ -42,6 +41,7 @@ var {
   switchTab,
   switchDay,
   loadFriendsSchedules,
+  openSharingSettings,
 } = require('../../actions');
 
 import type {Session} from '../../reducers/sessions';
@@ -57,7 +57,6 @@ type Props = {
   sessions: Array<Session>;
   friends: Array<FriendsSchedule>;
   schedule: Schedule;
-  navigator: Navigator;
   logOut: () => void;
   jumpToSchedule: (day: number) => void;
   loadFriendsSchedules: () => void;
@@ -116,19 +115,16 @@ class MyScheduleView extends React.Component {
         day={1}
         sessions={this.props.sessions}
         renderEmptyList={this.renderEmptySessionsList}
-        navigator={this.props.navigator}
       />,
       <ScheduleListView
         title="Day 2"
         day={2}
         sessions={this.props.sessions}
         renderEmptyList={this.renderEmptySessionsList}
-        navigator={this.props.navigator}
       />,
       <FriendsListView
         title="Friends"
         friends={this.props.friends}
-        navigator={this.props.navigator}
       />,
     ];
   }
@@ -159,7 +155,7 @@ class MyScheduleView extends React.Component {
   }
 
   openSharingSettings() {
-    this.props.navigator.push({shareSettings: 1});
+    this.props.openSharingSettings();
   }
 
   handleSegmentChanged(segment) {
@@ -195,6 +191,7 @@ function actions(dispatch) {
       switchDay(day),
     ]),
     loadFriendsSchedules: () => dispatch(loadFriendsSchedules()),
+    openSharingSettings: () => dispatch(openSharingSettings()),
   };
 }
 

--- a/js/tabs/schedule/ScheduleListView.js
+++ b/js/tabs/schedule/ScheduleListView.js
@@ -25,18 +25,20 @@
 
 var F8SessionCell = require('F8SessionCell');
 var FilterSessions = require('./filterSessions');
-var Navigator = require('Navigator');
 var React = require('React');
 var SessionsSectionHeader = require('./SessionsSectionHeader');
 var PureListView = require('../../common/PureListView');
 var groupSessions = require('./groupSessions');
+
+var { connect } = require('react-redux');
+var { openSession } = require('../../actions');
 
 import type {Session} from '../../reducers/sessions';
 
 type Props = {
   day: number;
   sessions: Array<Session>;
-  navigator: Navigator;
+  openSession: Function;
   renderEmptyList?: (day: number) => ReactElement;
 };
 
@@ -87,7 +89,7 @@ class ScheduleListView extends React.Component {
   renderRow(session: Session, day: number) {
     return (
       <F8SessionCell
-        onPress={() => this.openSession(session, day)}
+        onPress={() => this.props.openSession(session.id, session.day)}
         session={session}
       />
     );
@@ -96,14 +98,6 @@ class ScheduleListView extends React.Component {
   renderEmptyList(): ?ReactElement {
     const {renderEmptyList} = this.props;
     return renderEmptyList && renderEmptyList(this.props.day);
-  }
-
-  openSession(session: Session, day: number) {
-    this.props.navigator.push({
-      day,
-      session,
-      allSessions: this.state.todaySessions,
-    });
   }
 
   storeInnerRef(ref: ?PureListView) {
@@ -118,5 +112,15 @@ class ScheduleListView extends React.Component {
     return this._innerRef && this._innerRef.getScrollResponder();
   }
 }
+
+function actions(dispatch) {
+  return {
+    openSession: (session, day) => {
+      dispatch(openSession(session, day));
+    },
+  };
+}
+
+ScheduleListView = connect(null, actions, null, { withRef: true})(ScheduleListView);
 
 module.exports = ScheduleListView;

--- a/js/tabs/schedule/SharingSettingsModal.js
+++ b/js/tabs/schedule/SharingSettingsModal.js
@@ -27,16 +27,14 @@ var F8Button = require('F8Button');
 var React = require('React');
 var StyleSheet = require('StyleSheet');
 var View = require('View');
-var Navigator = require('Navigator');
 var FriendsUsingApp = require('./FriendsUsingApp');
 var SharingSettingsCommon = require('./SharingSettingsCommon');
 
-var { setSharingEnabled } = require('../../actions');
+var { back, setSharingEnabled } = require('../../actions');
 var { connect } = require('react-redux');
 
 class SharingSettingsModal extends React.Component {
   props: {
-    navigator: Navigator;
     dispatch: () => void;
   };
 
@@ -63,7 +61,7 @@ class SharingSettingsModal extends React.Component {
 
   handleSetSharing(enabled: boolean) {
     this.props.dispatch(setSharingEnabled(enabled));
-    this.props.navigator.pop();
+    this.props.dispatch(back());
   }
 }
 

--- a/js/tabs/schedule/SharingSettingsScreen.js
+++ b/js/tabs/schedule/SharingSettingsScreen.js
@@ -28,21 +28,19 @@ var React = require('React');
 var StyleSheet = require('StyleSheet');
 var { Text } = require('F8Text');
 var FriendsUsingApp = require('./FriendsUsingApp');
-var Navigator = require('Navigator');
 var Switch = require('Switch');
 var View = require('View');
 var F8Header = require('F8Header');
 var StatusBar = require('StatusBar');
 var SharingSettingsCommon = require('./SharingSettingsCommon');
 
-var { setSharingEnabled, logOutWithPrompt } = require('../../actions');
+var { back, setSharingEnabled, logOutWithPrompt } = require('../../actions');
 var { connect } = require('react-redux');
 
 import type {State as User} from '../../reducers/user';
 
 class SharingSettingsScreen extends React.Component {
   props: {
-    navigator: Navigator;
     dispatch: () => void;
     sharedSchedule: boolean;
     user: User;
@@ -81,7 +79,7 @@ class SharingSettingsScreen extends React.Component {
             icon: require('../../common/img/back.png'),
             title: 'Back',
             layout: 'icon',
-            onPress: () => this.props.navigator.pop(),
+            onPress: () => this.props.dispatch(back()),
           }}
           rightItem={{
             icon: require('./img/logout.png'),


### PR DESCRIPTION
- Create a bunch of navigation actions
- Persist navigation state in redux store.navigation.openModals
- Initial "LoginScreen" is part of the main stack as part of the initial state
- Put nav logic into reducer
- Switch F8Navigator from Navigator to NavigationAnimatedView
- Test on iOS and Android

Known problems:
- Bad states when tapping away from android drawers instead of using back button
- Untested push notifs

I'd greatly appreciate some support from the community to review and help test the code!
