### PR TITLE
Fix issue of pinning with Animated

### DIFF
--- a/js/common/ListContainer.js
+++ b/js/common/ListContainer.js
@@ -286,7 +286,7 @@ class ListContainer extends React.Component {
     // If native pinning is not available, fallback to Animated
     if (!NativeModules.F8Scrolling) {
       var distance = EMPTY_CELL_HEIGHT - this.state.stickyHeaderHeight;
-      var translateY = 0; this.state.anim.interpolate({
+      var translateY = this.state.anim.interpolate({
         inputRange: [0, distance],
         outputRange: [distance, 0],
         extrapolateRight: 'clamp',

--- a/js/common/ListContainer.js
+++ b/js/common/ListContainer.js
@@ -80,7 +80,8 @@ class RelayLoading extends React.Component {
   render() {
     const child = React.Children.only(this.props.children);
     if (!child.type.getFragmentNames) {
-      return child;
+      var {minContentHeight} = this.props;
+      return React.cloneElement(child, {minContentHeight});
     }
     return (
       <RelayRenderer
@@ -180,7 +181,7 @@ class ListContainer extends React.Component {
         <View style={styles.headerWrapper}>
           <ParallaxBackground
             minHeight={this.state.stickyHeaderHeight + F8Header.height}
-            maxHeight={EMPTY_CELL_HEIGHT + this.state.stickyHeaderHeight + F8Header.height}
+            maxHeight={EMPTY_CELL_HEIGHT + F8Header.height}
             offset={this.state.anim}
             backgroundImage={this.props.backgroundImage}
             backgroundShift={backgroundShift}
@@ -199,7 +200,8 @@ class ListContainer extends React.Component {
         <ViewPager
           count={segments.length}
           selectedIndex={this.state.idx}
-          onSelectedIndexChange={this.handleSelectSegment}>
+          onSelectedIndexChange={this.handleSelectSegment}
+          fakeHeaderHeight={EMPTY_CELL_HEIGHT - this.state.stickyHeaderHeight}>
           {content}
         </ViewPager>
         {this.renderFloatingStickyHeader(stickyHeader)}

--- a/js/common/ParallaxBackground.js
+++ b/js/common/ParallaxBackground.js
@@ -132,7 +132,7 @@ class ParallaxBackground extends React.Component {
     const {minHeight, maxHeight, offset} = this.props;
     const length = maxHeight - minHeight;
     const opacity = offset.interpolate({
-      inputRange: [0, length - 40],
+      inputRange: [0, length],
       outputRange: [1, 0],
       extrapolate: 'clamp',
     });

--- a/js/common/PureListView.js
+++ b/js/common/PureListView.js
@@ -122,7 +122,6 @@ class PureListView extends React.Component {
 PureListView.defaultProps = {
   data: [],
   contentInset: { top: 0, bottom: 0 },
-  // TODO: This has to be scrollview height + fake header
   minContentHeight: Dimensions.get('window').height + 20,
   renderSeparator: (sectionID, rowID) => <View style={styles.separator} key={rowID} />,
 };

--- a/js/common/ViewPager.js
+++ b/js/common/ViewPager.js
@@ -137,10 +137,13 @@ class ViewPager extends React.Component {
 
   renderContent(): Array<ReactElement> {
     var {width, height} = this.state;
+    var {fakeHeaderHeight} = this.props;
     var style = Platform.OS === 'ios' && styles.card;
     return React.Children.map(this.props.children, (child, i) => (
       <View style={[style, {width, height}]} key={'r_' + i}>
-        {child}
+        {React.cloneElement(child, {
+          minContentHeight: fakeHeaderHeight + height - 49,
+        })}
       </View>
     ));
   }


### PR DESCRIPTION
If native pinning is not available, F8 will use Animated instead to pin sticky header. `translateY` hasn't been set properly so the sticky header is not floating at all.