### PR TITLE
Remove hardcoded Parse Server IP

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,5 +22,7 @@ services:
       - "4040:4040"
   graphql:
     build: ./server/graphql
+    environment:
+      - PARSE_URL=http://parse:1337/parse
     ports:
       - "4000:4000"

--- a/server/graphql/Dockerfile
+++ b/server/graphql/Dockerfile
@@ -4,5 +4,4 @@ ADD . .
 RUN ["npm", "install"]
 RUN ["npm", "run", "build"]
 
-ENV PARSE_URL http://192.168.65.1:1337/parse
 ENTRYPOINT [ "node", "lib/index.js" ]


### PR DESCRIPTION
There's an easier way to link containers:
https://docs.docker.com/compose/networking/

### Test Plan

Ran this query in [Graphiql](http://localhost:4000/graphql?query=%7B%0A%20%20demos%20%7B%0A%20%20%20%20title%0A%20%20%7D%0A%7D%0A)
```
{
  demos {
    title
  }
}
```

Before this change the query would hang forever, after this change instantly got the reply.