### PR TITLE
Use node v8.11.x due to issue with http2

### DIFF
--- a/server/parse-server/Dockerfile
+++ b/server/parse-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.4-alpine
+FROM node:8.11-alpine
 
 RUN ["npm", "install", "-g", "parse-server"]
 


### PR DESCRIPTION
Solution as suggested on https://github.com/parse-community/parse-server/issues/4976